### PR TITLE
Add code styling to clarify inline code snippets and fix readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ GMO skin for MediaWiki
 
 This is meant to be a checked out using git submodules, so:
 
-  $ git clone https://gerrit.wikimedia.org/r/p/mediawiki/core wiki
-  $ cd wiki
-  $ git checkout REL1_19
-  $ cp ~/LocalSettingsSTORAGE/LocalSettings.php .
-  $ git submodule add https://github.com/mozilla/mediawiki-skins-gmo.git extensions/gmo
-  $ for i in extensions/gmo/skins/*; do ln -s ../$i skins ; done
-  $ awk '/(path|url) =/ {print $3}' extensions/gmo/gitmodules | xargs -n 2 git submodule add -f
+    $ git clone https://gerrit.wikimedia.org/r/p/mediawiki/core wiki
+    $ cd wiki
+    $ git checkout REL1_19
+    $ cp ~/LocalSettingsSTORAGE/LocalSettings.php .
+    $ git submodule add https://github.com/mozilla/mediawiki-skins-gmo.git extensions/gmo
+    $ for i in extensions/gmo/skins/*; do ln -s ../$i skins ; done
+    $ awk '/(path|url) =/ {print $3}' extensions/gmo/gitmodules | xargs -n 2 git submodule add -f

--- a/skins/gmo/style/screen.css
+++ b/skins/gmo/style/screen.css
@@ -321,3 +321,11 @@ table.rimage {
     display: inline;
     padding-right: 10px;
 }
+
+code {
+    margin: 0px 2px;
+    padding: 0px 5px;
+    background-color: rgb(240, 240, 240);
+    border: 1px solid rgb(187, 187, 187);
+    border-radius: 5px;
+}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1034201

Currently inline code snippets, using the `<code>` tag are rendered like this

![current style](http://i.imgur.com/RgxqfgI.png)

This styling makes it difficult to differentiate between the code and the surrounding text as the only differentiator is the change from a variable width font to a fixed width font.

Github uses, in my opinion, an excellent styling to call out inline code by
- surrounding the span in a box
- using a different background

This PR adds a `<code>` style css block which creates a clearer styling. With this style in place, inline code now looks like this :

![proposed style](http://i.imgur.com/eNbC4ur.png)
